### PR TITLE
Add generation for nether and end dimensions

### DIFF
--- a/mcexplore.1
+++ b/mcexplore.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: mcexplore
 .\"    Author: [see the "Authors" section]
-.\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 10/16/2013
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 04/13/2021
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MCEXPLORE" "1" "10/16/2013" "\ \&" "\ \&"
+.TH "MCEXPLORE" "1" "04/13/2021" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -79,6 +79,11 @@ Set the Z offset to generate land around\&. Defaults to the server\(cqs spawn po
 \fB\-r, \-\-regions\fR
 .RS 4
 When enabled, measure in regions instead of chunks\&.
+.RE
+.PP
+\fB\-d, \-\-dimension\fR <dimension>
+.RS 4
+Set which dimension to generate\&. Acceptable values: nether, end
 .RE
 .SH "AUTHORS"
 .sp

--- a/mcexplore.1.txt
+++ b/mcexplore.1.txt
@@ -57,6 +57,9 @@ Options
 *-r, --regions*::
 	When enabled, measure in regions instead of chunks.
 
+*-d, --dimension* <dimension>::
+	Set which dimension to generate. Acceptable values: nether, end
+
 Authors
 -------
 


### PR DESCRIPTION
Adds generation for nether and end dimensions. Can be activated by -d or --dimension.
World spawn is limited to the overworld so it copies minecraft:the_nether or minecraft:the_end in level.dat to minecraft:overworld and moves the region folder to be restored later. After completion the backup level.dat restores the original generation along with the region folder. Unfortunately was unable to add custom dimensions due lack of information on coupling namespace information in level.dat with the associated region folder.